### PR TITLE
change the way we update professions in the user serialiser

### DIFF
--- a/api/ellandi/registration/serializers.py
+++ b/api/ellandi/registration/serializers.py
@@ -84,15 +84,15 @@ class UserLanguageSerializer(serializers.HyperlinkedModelSerializer):
         fields = ["id", "user", "type", "language", "level", "created_at", "modified_at"]
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     skills = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name="userskill-detail")
     languages = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name="userlanguage-detail")
     email = serializers.CharField(read_only=True)
+    professions = serializers.SlugRelatedField(
+        many=True, queryset=Profession.objects.all(), read_only=False, slug_field="name"
+    )
 
     class Meta:
-        skills = UserSkillSerializer(many=True, read_only=True)
-        languages = UserLanguageSerializer(many=True, read_only=True)
-
         model = get_user_model()
         fields = [
             "id",

--- a/api/tests/test_registration.py
+++ b/api/tests/test_registration.py
@@ -52,9 +52,11 @@ def test_put(client, user_id):
         "first_name": "Jane",
         "last_name": "Brown",
         "professions": [
-            f"{TEST_SERVER_URL}professions/operational-research-service/",
-            f"{TEST_SERVER_URL}professions/policy/",
+            "Operational Research Service",
+            "Policy",
+            "Other",
         ],
+        "profession_other": "A new and exciting profession",
         "function": "Analysis",
     }
     response = client.put(f"/users/{user_id}/", data=updated_user_data)
@@ -62,6 +64,8 @@ def test_put(client, user_id):
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["last_name"] == "Brown"
     assert response.json()["function"] == "Analysis"
+    assert response.json()["professions"][1] == "Policy"
+    assert response.json()["profession_other"] == "A new and exciting profession"
 
 
 @utils.with_logged_in_client

--- a/api/tests/test_registration.py
+++ b/api/tests/test_registration.py
@@ -64,7 +64,8 @@ def test_put(client, user_id):
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["last_name"] == "Brown"
     assert response.json()["function"] == "Analysis"
-    assert response.json()["professions"][1] == "Policy"
+    assert len(response.json()["professions"]) == 3
+    assert "Policy" in response.json()["professions"]
     assert response.json()["profession_other"] == "A new and exciting profession"
 
 


### PR DESCRIPTION
Partially fixes #174 - addresses issues around "Profession"

- Can now update on user endpoint using eg `"profession": ["Policy Profession", "Other"]`.
- Field for `profession_other` has been added  and "Other" is in the list of options for profession (this is already in develop).