### PR TITLE
Replace 'Other' Primary profession with value provided by the user

### DIFF
--- a/web/components/Form/Register/PrimaryProfessionForm.tsx
+++ b/web/components/Form/Register/PrimaryProfessionForm.tsx
@@ -35,7 +35,16 @@ const PrimaryProfessionForm: FC<
     authFetch(fetchMe)
   )
 
-  const professions = useMemo(() => data?.professions || [], [data])
+  const professions = useMemo(() => {
+    return (
+      data?.professions.map((profession) => {
+        if (profession.toLowerCase() === 'other') {
+          return data.profession_other
+        }
+        return profession
+      }) || []
+    )
+  }, [data])
 
   useEffect(() => {
     if (!isLoading && professions.length < 2) router.push(props.backUrl, undefined)


### PR DESCRIPTION
Closes https://trello.com/c/NbU6hQ4f/72-bug-fix-other-profession-show-user-text-on-primary-profession-step-and-profile

<img width="619" alt="image" src="https://user-images.githubusercontent.com/111270319/185566883-859a832f-8c7f-4455-960c-cd1c883665ce.png">
<img width="673" alt="image" src="https://user-images.githubusercontent.com/111270319/185566926-1561ece6-0b22-4232-9d84-4f7e52239ee1.png">
