### PR TITLE
fix prod api url bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup prod api url
+        if:  ${{ github.ref_name == 'main' }}
+        run: echo "NEXT_PUBLIC_API_URL=https://ellandi-api.london.cloudapps.digital" >> $GITHUB_ENV
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This will/should set the url to the prod api url if its the main branch before it is passed to the docker container.

![image](https://user-images.githubusercontent.com/2026055/186177334-64a4500b-09d7-47aa-9d96-422cec07e586.png)

you can see at the top that `NEXT_PUBLIC_API_URL` set with `sandbox` in it but at the bottom the `echo` of that var shows the prod api url 

Obviously due to environment limitations - this hasn't been tested thoroughly but shouldn't make things any worse if it doesn't quit work - so I think we can merge direct to main.