### PR TITLE
Resend email verify

### DIFF
--- a/api/ellandi/urls.py
+++ b/api/ellandi/urls.py
@@ -25,6 +25,7 @@ api_urlpatterns = [
     path("me/learning-social/", views.me_learning_social_view),
     path("me/learning-formal/", views.me_learning_formal_view),
     path("me/learnings/", views.me_learning_view),
+    path("me/send-verification-email/", verification.me_send_verification_email_view),
     path("user/<uuid:user_id>/verify/<str:token>/", verification.verification_view),
     path("password-reset/", verification.password_reset_ask_view),
     path("user/<uuid:user_id>/password-reset/<str:token>/", verification.password_reset_use_view),

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -53,6 +53,22 @@ def send_password_reset_email(user):
     return _send_token_email(user, **data)
 
 
+
+@extend_schema(
+    responses=serializers.UserSerializer,
+)
+@decorators.api_view(["POST"])
+@decorators.permission_classes((permissions.IsAuthenticated,))
+def me_send_verification_email_view(request):
+    user = request.user
+    send_verification_email(user)
+    serializer = serializers.UserSerializer(user)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+
+
+
 @extend_schema(
     responses=serializers.UserSerializer,
 )

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -89,7 +89,6 @@ def verification_view(request, user_id, token):
 
 @extend_schema(
     request=serializers.PasswordResetAskSerializer,
-    responses=serializers.UserSerializer,
 )
 @decorators.api_view(["POST"])
 @decorators.permission_classes((permissions.AllowAny,))

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -53,7 +53,6 @@ def send_password_reset_email(user):
     return _send_token_email(user, **data)
 
 
-
 @extend_schema(
     responses=serializers.UserSerializer,
 )
@@ -64,9 +63,6 @@ def me_send_verification_email_view(request):
     send_verification_email(user)
     serializer = serializers.UserSerializer(user)
     return Response(serializer.data, status=status.HTTP_200_OK)
-
-
-
 
 
 @extend_schema(

--- a/api/tests/test_token_verification.py
+++ b/api/tests/test_token_verification.py
@@ -48,7 +48,6 @@ def test_verify_email(client):
     assert user.verified
 
 
-
 @utils.with_logged_in_client
 @override_settings(SEND_VERIFICATION_EMAIL=True)
 def test_resend_verify_email(client, user_id):

--- a/api/tests/test_token_verification.py
+++ b/api/tests/test_token_verification.py
@@ -48,6 +48,24 @@ def test_verify_email(client):
     assert user.verified
 
 
+
+@utils.with_logged_in_client
+@override_settings(SEND_VERIFICATION_EMAIL=True)
+def test_resend_verify_email(client, user_id):
+    user = User.objects.get(id=user_id)
+
+    response = client.post("/me/send-verification-email/")
+    assert response.status_code == 200
+
+    url = _get_latest_email_url("verify")
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json()["email"] == user.email
+
+    user = User.objects.get(email=user.email)
+    assert user.verified
+
+
 @utils.with_client
 @override_settings(SEND_VERIFICATION_EMAIL=True)
 def test_verify_email_bad_token(client):


### PR DESCRIPTION
Fixes #488 

@rottitime Note that this is a POST not a GET (I can add PATCH if you want).  Also I changed the name of the endpoint to `me/send-verification-email/` because it doesn't actually verify the email, it just sends it.