### PR TITLE
Bug fix: Duration calculation based on standard office time of 7.5 hours a day

### DIFF
--- a/web/components/Form/Duration/Duration.test.tsx
+++ b/web/components/Form/Duration/Duration.test.tsx
@@ -44,12 +44,12 @@ describe('Duration', () => {
       expect(minutes).toHaveValue(null)
       expect(hours).toHaveValue(null)
 
-      // await userEvent.type(hours, '1')
-      // expect(mockChange).toHaveBeenLastCalledWith(2940)
-      // expect(minutes).toHaveValue(null)
+      await userEvent.type(hours, '1')
+      expect(mockChange).toHaveBeenLastCalledWith(960)
+      expect(minutes).toHaveValue(null)
 
-      // await userEvent.type(minutes, '55')
-      // expect(mockChange).toHaveBeenLastCalledWith(2995)
+      await userEvent.type(minutes, '55')
+      expect(mockChange).toHaveBeenLastCalledWith(1015)
     })
   })
 })

--- a/web/components/Form/Duration/Duration.test.tsx
+++ b/web/components/Form/Duration/Duration.test.tsx
@@ -40,16 +40,16 @@ describe('Duration', () => {
 
       await userEvent.type(days, '2')
       expect(days).toHaveValue(2)
-      expect(mockChange).toHaveBeenLastCalledWith(2880)
+      expect(mockChange).toHaveBeenLastCalledWith(900)
       expect(minutes).toHaveValue(null)
       expect(hours).toHaveValue(null)
 
-      await userEvent.type(hours, '1')
-      expect(mockChange).toHaveBeenLastCalledWith(2940)
-      expect(minutes).toHaveValue(null)
+      // await userEvent.type(hours, '1')
+      // expect(mockChange).toHaveBeenLastCalledWith(2940)
+      // expect(minutes).toHaveValue(null)
 
-      await userEvent.type(minutes, '55')
-      expect(mockChange).toHaveBeenLastCalledWith(2995)
+      // await userEvent.type(minutes, '55')
+      // expect(mockChange).toHaveBeenLastCalledWith(2995)
     })
   })
 })

--- a/web/components/Form/Duration/Duration.tsx
+++ b/web/components/Form/Duration/Duration.tsx
@@ -25,7 +25,8 @@ const Duration: FC<Props> = forwardRef<HTMLDivElement, Props>(
       combine(
         daysRef.current.valueAsNumber || 0,
         hoursRef.current.valueAsNumber || 0,
-        minutesRef.current.valueAsNumber || 0
+        minutesRef.current.valueAsNumber || 0,
+        7.5
       )
 
     useEffect(() => {

--- a/web/components/UI/PercentageBar/PercentageBar.tsx
+++ b/web/components/UI/PercentageBar/PercentageBar.tsx
@@ -1,6 +1,5 @@
 import { Box, styled, Typography, useTheme } from '@mui/material'
 import { FC } from 'react'
-import Tooltip from '../Tooltip/Tooltip'
 import { Props } from './types'
 
 const StyledPercentageBar = styled(Box)`
@@ -27,12 +26,12 @@ const PercentageBar: FC<Props> = ({ marks, data, ...props }) => {
     <StyledPercentageBar {...props}>
       <Box className="bar">
         {data.map(({ percentage, label, color }) => (
-          <Tooltip title={label} key={label}>
-            <Box
-              aria-label={label}
-              sx={{ width: `${percentage}%`, backgroundColor: colors[color] }}
-            />
-          </Tooltip>
+          <Box
+            title={label}
+            key={label}
+            aria-label={label}
+            sx={{ width: `${percentage}%`, backgroundColor: colors[color] }}
+          />
         ))}
       </Box>
       {marks &&

--- a/web/lib/date-utils.test.ts
+++ b/web/lib/date-utils.test.ts
@@ -41,4 +41,16 @@ describe('combineDaysMinutesHoursToMinutes()', () => {
     expect(combineDaysMinutesHoursToMinutes(0, 1, 10)).toEqual(70)
     expect(combineDaysMinutesHoursToMinutes(7, 18, 48)).toEqual(11208)
   })
+
+  it('based on 7.5 hours a day', () => {
+    const hoursPerDay = 7.5
+    expect(combineDaysMinutesHoursToMinutes(0, 0, 0, hoursPerDay)).toEqual(0)
+    expect(combineDaysMinutesHoursToMinutes(0, 0, 25, hoursPerDay)).toEqual(25)
+    expect(combineDaysMinutesHoursToMinutes(0, 0, 450, hoursPerDay)).toEqual(450)
+    expect(combineDaysMinutesHoursToMinutes(0, 7.5, 0, hoursPerDay)).toEqual(450)
+    expect(combineDaysMinutesHoursToMinutes(1, 0, 0, hoursPerDay)).toEqual(450)
+    expect(combineDaysMinutesHoursToMinutes(2, 0, 0, hoursPerDay)).toEqual(900)
+    expect(combineDaysMinutesHoursToMinutes(0, 1, 10, hoursPerDay)).toEqual(70)
+    expect(combineDaysMinutesHoursToMinutes(7, 18, 48, hoursPerDay)).toEqual(4278)
+  })
 })

--- a/web/lib/date-utils.ts
+++ b/web/lib/date-utils.ts
@@ -35,5 +35,6 @@ export const splitMinutes = (
 export const combineDaysMinutesHoursToMinutes = (
   days: number,
   hours: number,
-  minutes: number
-): number => days * 1440 + hours * 60 + minutes
+  minutes: number,
+  hoursPerDay = 24
+): number => (days * hoursPerDay + hours) * 60 + minutes


### PR DESCRIPTION
Fixes a bug spotted on demo. Days was not converted based on the standard office time (7.5hours a day)
https://trello.com/c/heMnwgeo/186-bug-fix-learning-goals-calculation