### PR TITLE
Add the internal url to all environments

### DIFF
--- a/manifests/demo/ellandi-api_manifest.yml
+++ b/manifests/demo/ellandi-api_manifest.yml
@@ -6,6 +6,8 @@ applications:
   routes:
   - route: ellandi-api-demo.london.cloudapps.digital
     protocol: http1
+  - route: ellandi-api-sandbox.apps.internal
+    protocol: http1
   processes:
   - type: web
     instances: 1

--- a/manifests/develop/ellandi-api_manifest.yml
+++ b/manifests/develop/ellandi-api_manifest.yml
@@ -6,6 +6,8 @@ applications:
   routes:
   - route: ellandi-api-develop.london.cloudapps.digital
     protocol: http1
+  - route: ellandi-api-sandbox.apps.internal
+    protocol: http1
   processes:
   - type: web
     instances: 1

--- a/manifests/prod/ellandi-api_manifest.yml
+++ b/manifests/prod/ellandi-api_manifest.yml
@@ -6,6 +6,8 @@ applications:
   routes:
   - route: ellandi-api.london.cloudapps.digital
     protocol: http1
+  - route: ellandi-api-sandbox.apps.internal
+    protocol: http1
   processes:
   - type: web
     instances: 1


### PR DESCRIPTION
Minor oversight in the manifest. Needed to add the apps.internal urls for api