### PR TITLE
Add Github scheduling test

### DIFF
--- a/.github/workflows/cf-cron.yml
+++ b/.github/workflows/cf-cron.yml
@@ -1,0 +1,18 @@
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  cron_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download CF CLI
+        run: curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | tar -zx
+
+      - name: CF login
+        run: ./cf login -a api.london.cloud.service.gov.uk -u "${{ secrets.CF_USER }}" -p "${{ secrets.CF_PASSWORD }}" -o co-i-ai -s "$CF_SPACE"
+
+      - name: Every time
+        run: cf run-task cf-cron --command "curl --head https://ellandi-sandbox.london.cloudapps.digital"


### PR DESCRIPTION
this test will start a stop Cloudfoundry app to run the cron task and then kill it