### PR TITLE
Feature/learning sort

### DIFF
--- a/api/ellandi/registration/views.py
+++ b/api/ellandi/registration/views.py
@@ -297,9 +297,12 @@ def make_learning_view(serializer_class, learning_type):
         user = request.user
         queryset = models.Learning.objects.filter(user=user)
         _learning_type = learning_type or request.query_params.get("learning_type", None)
+        sortfield = request.query_params.get("sortfield", None)
         if _learning_type:
             queryset = queryset.filter(learning_type=_learning_type)
         if request.method == "GET":
+            if sortfield:
+                queryset = queryset.order_by(sortfield)
             serializer = serializer_class(queryset, many=True)
             return Response(serializer.data)
         elif request.method == "PATCH":

--- a/api/tests/test_learning.py
+++ b/api/tests/test_learning.py
@@ -45,12 +45,6 @@ def test_me_learning_formal(client, user_id):
 def test_me_learning_patch_get_delete(client, user_id):
     data = [
         {
-            "name": "OTJ learning",
-            "duration_minutes": 666,
-            "date_completed": "2022-09-20",
-            "learning_type": "On the job",
-        },
-        {
             "name": "Did some on the job learning",
             "duration_minutes": 32767,
             "date_completed": "2022-09-21",
@@ -78,19 +72,29 @@ def test_me_learning_patch_get_delete(client, user_id):
 
     for i, learning_type in enumerate(("On the job", "Social", "Formal")):
         response = client.get(f"/api/me/learnings/?learning_type={learning_type}")
-
         result = response.json()
         for key, value in data[i].items():
-            assert result[0][key] == value
-            assert all_result[i][key] == value
+            assert result[0][key] == value, result
+            assert all_result[i][key] == value, all_result
 
-    response = client.get(f"/api/me/learnings/?learning_type=On the job&?sortfield=name")
+    more_data = [
+        {
+            "name": "OTJ learning",
+            "duration_minutes": 666,
+            "date_completed": "2022-09-20",
+            "learning_type": "On the job",
+        },
+    ]
+    response = client.patch("/api/me/learnings/", json=more_data)
+    assert response.status_code == status.HTTP_200_OK, response
+
+    response = client.get(f"/api/me/learnings/?learning_type=On the job&sortfield=name")
     result = response.json()
     assert len(result) == 2
-    assert result[0]["name"] == "Did some on the job learning"
+    assert result[0]["name"] == "Did some on the job learning", result
     assert result[1]["learning_type"] == "On the job"
 
-    response = client.get(f"/api/me/learnings/?learning_type=sortfield=-duration_minutes")
+    response = client.get(f"/api/me/learnings/?sortfield=-duration_minutes")
     result = response.json()
     assert len(result) == 4
     assert result[3]["duration_minutes"] == 666

--- a/api/tests/test_learning.py
+++ b/api/tests/test_learning.py
@@ -45,6 +45,12 @@ def test_me_learning_formal(client, user_id):
 def test_me_learning_patch_get_delete(client, user_id):
     data = [
         {
+            "name": "OTJ learning",
+            "duration_minutes": 666,
+            "date_completed": "2022-09-20",
+            "learning_type": "On the job",
+        },
+        {
             "name": "Did some on the job learning",
             "duration_minutes": 32767,
             "date_completed": "2022-09-21",
@@ -77,6 +83,17 @@ def test_me_learning_patch_get_delete(client, user_id):
         for key, value in data[i].items():
             assert result[0][key] == value
             assert all_result[i][key] == value
+
+    response = client.get(f"/api/me/learnings/?learning_type=On the job&?sortfield=name")
+    result = response.json()
+    assert len(result) == 2
+    assert result[0]["name"] == "Did some on the job learning"
+    assert result[1]["learning_type"] == "On the job"
+
+    response = client.get(f"/api/me/learnings/?learning_type=sortfield=-duration_minutes")
+    result = response.json()
+    assert len(result) == 4
+    assert result[3]["duration_minutes"] == 666
 
     formal_learning = [learning for learning in all_result if learning["name"] == "Did some formal learning"][0]
     id_to_delete = formal_learning["id"]

--- a/api/tests/test_learning.py
+++ b/api/tests/test_learning.py
@@ -88,13 +88,13 @@ def test_me_learning_patch_get_delete(client, user_id):
     response = client.patch("/api/me/learnings/", json=more_data)
     assert response.status_code == status.HTTP_200_OK, response
 
-    response = client.get(f"/api/me/learnings/?learning_type=On the job&sortfield=name")
+    response = client.get("/api/me/learnings/?learning_type=On the job&sortfield=name")
     result = response.json()
     assert len(result) == 2
     assert result[0]["name"] == "Did some on the job learning", result
     assert result[1]["learning_type"] == "On the job"
 
-    response = client.get(f"/api/me/learnings/?sortfield=-duration_minutes")
+    response = client.get("/api/me/learnings/?sortfield=-duration_minutes")
     result = response.json()
     assert len(result) == 4
     assert result[3]["duration_minutes"] == 666


### PR DESCRIPTION
Fixes #573.

@rottitime - you can now pass in `sortfield` however I didn't add `sortorder=asc` as you can just pass in `-` before the fieldname to get descending (it's ascending by default). For example, `/me/learnings/?sortfield=-name` would sort descending.