### PR TITLE
Feature/rename service

### DIFF
--- a/api/ellandi/templates/email/password-reset.txt
+++ b/api/ellandi/templates/email/password-reset.txt
@@ -10,4 +10,4 @@ If you have a query about this notification, please email the support team: supp
 
 Regards
 
-Civil Service Skills and Learning
+Cabinet Office Skills and Learning

--- a/api/ellandi/templates/email/verification.txt
+++ b/api/ellandi/templates/email/verification.txt
@@ -11,4 +11,4 @@ If you have a query about this notification, please email the support team: supp
 
 Regards
 
-Civil Service Skills and Learning
+Cabinet Office Skills and Learning

--- a/api/ellandi/templates/email/verification.txt
+++ b/api/ellandi/templates/email/verification.txt
@@ -1,4 +1,4 @@
-Hi {{user.first_name}},
+Hi,
 
 Use the following link to confirm your email address:
 {{url|safe}}

--- a/api/ellandi/templates/email/verification.txt
+++ b/api/ellandi/templates/email/verification.txt
@@ -3,7 +3,7 @@ Hi {{user.first_name}},
 Use the following link to confirm your email address:
 {{url|safe}}
 
-You can then start using the Civil Service Skills and Learning Service.
+You can then start using the Cabinet Office Skills and Learning Service.
 
 The link is valid for 24 hours. If you use the link more than once, it will expire.
 

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -36,13 +36,13 @@ TOKEN_GENERATOR = TokenGenerator()
 EMAIL_MAPPING = {
     "verification": {
         "from_address": "support-ellandi@cabinetoffice.gov.uk",
-        "subject": "Civil Service Skills and Learning: confirm your email address",
+        "subject": "Cabinet Office Skills and Learning: confirm your email address",
         "template_name": "email/verification.txt",
         "url_path": "/signin/email/verify",
     },
     "password-reset": {
         "from_address": "support-ellandi@cabinetoffice.gov.uk",
-        "subject": "Civil Service Skills and Learning: password reset",
+        "subject": "Cabinet Office Skills and Learning: password reset",
         "template_name": "email/password-reset.txt",
         "url_path": "/signin/forgotten-password/reset",
     },


### PR DESCRIPTION
Rename "Civil Service Skills and Learning" to "Cabinet Office Skills and Learning" as per this Trello ticket: https://trello.com/c/BCifrw6D/244-rename-service-to-cabinet-office-skills-and-learning