### PR TITLE
Feature/697 has reports access

### DIFF
--- a/api/ellandi/registration/serializers.py
+++ b/api/ellandi/registration/serializers.py
@@ -208,7 +208,7 @@ class UserSerializer(serializers.ModelSerializer):
     email = serializers.CharField(read_only=True)
     professions = serializers.ListField(child=serializers.CharField(), read_only=False, required=False)
     has_direct_reports = serializers.BooleanField(required=False)
-    has_reporting_access = serializers.BooleanField(read_only=True, source="is_staff")
+    has_reports_access = serializers.BooleanField(read_only=True, source="is_staff")
 
     def update(self, instance, validated_data):
         single_fields_to_update = [
@@ -292,6 +292,7 @@ class UserSerializer(serializers.ModelSerializer):
             "skills_develop",
             "created_at",
             "modified_at",
+            "has_reports_access"
         ]
         read_only_fields = ["verified"]
 

--- a/api/ellandi/registration/serializers.py
+++ b/api/ellandi/registration/serializers.py
@@ -292,7 +292,7 @@ class UserSerializer(serializers.ModelSerializer):
             "skills_develop",
             "created_at",
             "modified_at",
-            "has_reports_access"
+            "has_reports_access",
         ]
         read_only_fields = ["verified"]
 

--- a/api/ellandi/registration/serializers.py
+++ b/api/ellandi/registration/serializers.py
@@ -208,6 +208,7 @@ class UserSerializer(serializers.ModelSerializer):
     email = serializers.CharField(read_only=True)
     professions = serializers.ListField(child=serializers.CharField(), read_only=False, required=False)
     has_direct_reports = serializers.BooleanField(required=False)
+    has_reporting_access = serializers.BooleanField(read_only=True, source="is_staff")
 
     def update(self, instance, validated_data):
         single_fields_to_update = [

--- a/api/ellandi/reporting.py
+++ b/api/ellandi/reporting.py
@@ -438,7 +438,6 @@ def staff_overview_view(request):
 
 
 def get_start_financial_year():
-    # TODO - assumed financial year starts 1st Apr - check
     today = datetime.date.today()
     year = today.year
     if today.month < 4:

--- a/api/tests/test_registration.py
+++ b/api/tests/test_registration.py
@@ -725,10 +725,10 @@ def test_has_reporting_access_admin(client, user_id):
     response = client.get("/api/me/")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data["has_reports_access"] == True
+    assert data["has_reports_access"]
     response = client.patch("/api/me/", json={"has_reports_access": False})
     data = response.json()
-    assert data["has_reports_access"] == True, "has_reports_access should be a read-only field"
+    assert data["has_reports_access"], "has_reports_access should be a read-only field"
 
 
 @utils.with_logged_in_client
@@ -736,4 +736,4 @@ def test_has_reporting_access_non_admin(client, user_id):
     response = client.get("/api/me/")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data["has_reports_access"] == False
+    assert not data["has_reports_access"]

--- a/api/tests/test_registration.py
+++ b/api/tests/test_registration.py
@@ -718,3 +718,22 @@ def test_me_skills_suggested(client, user_id):
     response = client.get("/api/me/skills-suggested/")
     assert response.status_code == status.HTTP_200_OK, response.status_code
     assert response.json() == [], response.json()
+
+
+@utils.with_logged_in_admin_client
+def test_has_reporting_access_admin(client, user_id):
+    response = client.get("/api/me/")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["has_reports_access"] == True
+    response = client.patch("/api/me/", json={"has_reports_access": False})
+    data = response.json()
+    assert data["has_reports_access"] == True, "has_reports_access should be a read-only field"
+
+
+@utils.with_logged_in_client
+def test_has_reporting_access_non_admin(client, user_id):
+    response = client.get("/api/me/")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["has_reports_access"] == False


### PR DESCRIPTION
Fixes #697 - adds `has_reports_access` field on the `me` endpoint. @rottitime - for info.

Assuming that I'm not adding pagination on the backend, #697 is done.