### PR TITLE
Token Types

### DIFF
--- a/api/ellandi/registration/views.py
+++ b/api/ellandi/registration/views.py
@@ -365,7 +365,7 @@ def make_learning_view(serializer_class, learning_type):
                 enum=["Formal", "Social", "On the job"],
             ),
         ],
-        responses=None,
+        responses=serializers.LearningSerializer(many=True),
     )
     @decorators.api_view(["GET", "PATCH"])
     @decorators.permission_classes((permissions.IsAuthenticated,))

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -23,7 +23,13 @@ def _strip_microseconds(dt):
     return dt.replace(microsecond=0, tzinfo=None)
 
 
-class TokenGenerator(PasswordResetTokenGenerator):
+class EmailVerifyTokenGenerator(PasswordResetTokenGenerator):
+    def _make_hash_value(self, user, timestamp):
+        email = user.email or ""
+        return f"{user.pk}{user.password}{timestamp}{email}"
+
+
+class PasswordResetTokenGenerator(PasswordResetTokenGenerator):
     def _make_hash_value(self, user, timestamp):
         login_timestamp = _strip_microseconds(user.last_login)
         email = user.email or ""
@@ -31,7 +37,8 @@ class TokenGenerator(PasswordResetTokenGenerator):
         return f"{user.pk}{user.password}{login_timestamp}{timestamp}{email}{token_timestamp}"
 
 
-TOKEN_GENERATOR = TokenGenerator()
+EMAIL_VERIFY_TOKEN_GENERATOR = EmailVerifyTokenGenerator()
+PASSWORD_RESET_TOKEN_GENERATOR = PasswordResetTokenGenerator()
 
 EMAIL_MAPPING = {
     "verification": {

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -41,7 +41,7 @@ EMAIL_VERIFY_TOKEN_GENERATOR = EmailVerifyTokenGenerator()
 PASSWORD_RESET_TOKEN_GENERATOR = PasswordResetTokenGenerator()
 
 EMAIL_MAPPING = {
-    "verification": {
+    "email-verification": {
         "from_address": "support-ellandi@cabinetoffice.gov.uk",
         "subject": "Cabinet Office Skills and Learning: confirm your email address",
         "template_name": "email/verification.txt",
@@ -77,7 +77,7 @@ def _send_token_email(user, subject, template_name, from_address, url_path, toke
 
 
 def send_verification_email(user):
-    data = EMAIL_MAPPING["verification"]
+    data = EMAIL_MAPPING["email-verification"]
     return _send_token_email(user, **data)
 
 

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -67,16 +67,12 @@ def _send_token_email(user, subject, template_name, from_address, url_path, toke
     url = str(furl.furl(url=web_host_url, path=url_path, query_params={"code": token, "user_id": str(user.id)}))
     context = dict(user=user, url=url)
     body = render_to_string(template_name, context)
-    try:
-        response = send_mail(
-            subject=subject,
-            message=body,
-            from_email=from_address,
-            recipient_list=[user.email],
-        )
-    # FIXME: Remove me after pentest
-    except:  # noqa
-        response = {}
+    response = send_mail(
+        subject=subject,
+        message=body,
+        from_email=from_address,
+        recipient_list=[user.email],
+    )
     return response
 
 

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -46,20 +46,22 @@ EMAIL_MAPPING = {
         "subject": "Cabinet Office Skills and Learning: confirm your email address",
         "template_name": "email/verification.txt",
         "url_path": "/signin/email/verify",
+        "token_generator": EMAIL_VERIFY_TOKEN_GENERATOR,
     },
     "password-reset": {
         "from_address": "support-ellandi@cabinetoffice.gov.uk",
         "subject": "Cabinet Office Skills and Learning: password reset",
         "template_name": "email/password-reset.txt",
         "url_path": "/signin/forgotten-password/reset",
+        "token_generator": PASSWORD_RESET_TOKEN_GENERATOR,
     },
 }
 
 
-def _send_token_email(user, subject, template_name, from_address, url_path):
+def _send_token_email(user, subject, template_name, from_address, url_path, token_generator):
     user.last_token_sent_at = datetime.datetime.now(tz=pytz.UTC)
     user.save()
-    token = TOKEN_GENERATOR.make_token(user)
+    token = token_generator.make_token(user)
     api_host_url = settings.HOST_URL.strip("/")
     web_host_url = settings.HOST_MAP[api_host_url]
     url = str(furl.furl(url=web_host_url, path=url_path, query_params={"code": token, "user_id": str(user.id)}))

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -186,7 +186,7 @@ def password_change_view(request):
 @decorators.permission_classes((permissions.AllowAny,))
 def check_token(request, user_id, token):
     token_type = request.query_params.get("type", "password-reset")
-    token_generator = EMAIL_MAPPING[token_type]['token_generator']
+    token_generator = EMAIL_MAPPING[token_type]["token_generator"]
     try:
         user = models.User.objects.get(id=user_id)
     except ObjectDoesNotExist:

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -8,7 +8,7 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import decorators, permissions, status
 from rest_framework.response import Response
 
@@ -176,6 +176,10 @@ def password_change_view(request):
 
 
 @extend_schema(
+    methods=["GET"],
+    parameters=[
+        OpenApiParameter(name="type", location=OpenApiParameter.QUERY, required=False, type=str),
+    ],
     responses=serializers.IsValidSerializer,
 )
 @decorators.api_view(["GET"])

--- a/api/tests/test_token_verification.py
+++ b/api/tests/test_token_verification.py
@@ -42,7 +42,14 @@ def test_verify_email(client):
 
     url = _get_latest_email_url("verify")
     user_id, _, token = url.strip("/").split("/")[-3:]
-    response = client.get(f"/api/user/{user_id}/token/{token}/valid/")
+    response = client.get(f"/api/user/{user_id}/token/{token}/valid/?type=email-verification")
+    assert response.json()["valid"]
+
+    response = client.post("/api/login/", json={"email": user_data["email"], "password": user_data["password"]})
+    assert response.status_code == 200
+    assert response.json()["token"]
+
+    response = client.get(f"/api/user/{user_id}/token/{token}/valid/?type=email-verification")
     assert response.json()["valid"]
 
     response = client.get(url)


### PR DESCRIPTION
This adds a different token type for email verification so that it doesn't get invalidated by login attempts.  I've had to change the `user/<uuid:user_id>/token/<str:token>/valid/` end point that checks tokens to accept a `?type=[email-verification|password-reset]` param, but I've made the default be `password-reset` so I don't think you will have to change anything on the frontend @rottitime 