### PR TITLE
Updated validation messaging for new password field

### DIFF
--- a/web/components/Form/ResetPasswordForm/ResetPasswordForm.test.tsx
+++ b/web/components/Form/ResetPasswordForm/ResetPasswordForm.test.tsx
@@ -48,7 +48,9 @@ describe('Page: Reset Password', () => {
       expect(fieldPassword).toHaveTextContent('Password must be 8 characters or more')
     })
 
-    expect(fieldPasswordConfirm).toHaveTextContent('This is a required field')
+    expect(fieldPasswordConfirm).toHaveTextContent(
+      'Enter your new password again to confirm'
+    )
 
     expect(mockSubmit).not.toHaveBeenCalledWith({ email })
   })

--- a/web/components/Form/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/web/components/Form/ResetPasswordForm/ResetPasswordForm.tsx
@@ -16,7 +16,7 @@ const schema: SchemaOf<FormData> = object().shape({
     .required('This is a required field'),
   new_password_confirm: string()
     .oneOf([ref('new_password'), null], 'Does not match with password')
-    .required('This is a required field')
+    .required('Enter your new password again to confirm')
 })
 
 const SignInForm: FC<Props> = ({ onFormSubmit, loading }) => {


### PR DESCRIPTION
Closes https://trello.com/c/6zWv06AK/133-sign-in-error-messages

<img width="703" alt="image" src="https://user-images.githubusercontent.com/111270319/201759734-9629b08e-eb93-4143-86d6-fede65ca5078.png">
