### PR TITLE
Add prod to recommender schedule

### DIFF
--- a/.github/workflows/cf-cron.yml
+++ b/.github/workflows/cf-cron.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        environment: [staging, develop, pentest]
+        environment: [prod, staging, develop]
 
     env:
       CF_SPACE: ${{ matrix.environment }}


### PR DESCRIPTION
This just needs to be merged in to `develop` to work.  - no need  to rush this to prod. 