### PR TITLE
Bug Fix:  registration returning null after verification

### DIFF
--- a/web/pages/register/step/[step].tsx
+++ b/web/pages/register/step/[step].tsx
@@ -47,7 +47,7 @@ const RegisterPage = ({ stepInt, nextUrl, backUrl, skip }: Props) => {
     Partial<RegisterUserResponse>
   >(async (data) => authFetch(updateUser, data), {
     onSuccess: async (data) => {
-      if (!!stepInt) queryClient.setQueryData(Query.Me, data)
+      queryClient.setQueryData(Query.Me, data)
       setError(null)
       router.push(nextUrl)
     },


### PR DESCRIPTION
Fixes: https://trello.com/c/72PT2EtK/287-bug-personal-details-not-showing-on-profile-after-completing-sign-up