### PR TITLE
Add dispatch deployments for infrastructure apps

### DIFF
--- a/.github/workflows/autoscale.yml
+++ b/.github/workflows/autoscale.yml
@@ -7,11 +7,17 @@ on:
       - pentest
       - develop
       - staging
-      - prod
     paths:
       - .github/workflows/autoscale.yml
       - 'autoscale/**'
-
+  workflow_dispatch:
+    branches:
+      - temp
+      - demo
+      - sandbox
+      - pentest
+      - develop
+      - prod
 jobs:
   configure_autoscaler:
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -9,6 +9,9 @@ on:
       - .github/workflows/metrics.yml
       - 'manifests/Metrics/PrometheusServer/**'
       - 'manifests/Metrics/alertmanager/**'
+  workflow_dispatch:
+    branches:
+      - develop
 
 jobs:
   deploy_prometheus:

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -6,11 +6,18 @@ on:
     branches:
       - develop
       - staging
-      - prod
       - pentest
     paths:
       - .github/workflows/proxy.yml
       - 'proxy/**'
+  workflow_dispatch:
+    branches:
+      - temp
+      - demo
+      - sandbox
+      - pentest
+      - develop
+      - prod
 
 permissions:
   packages: write


### PR DESCRIPTION
Adding dispatch deploy will allow deployments of these apps to be done with github gui without the need of 'act' installed locally