### PR TITLE
Fix issues with email verification and password reset

### DIFF
--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -108,7 +108,8 @@ def verification_view(request, user_id, token):
         user = models.User.objects.get(id=user_id)
         if user.verified:
             result = False
-        result = EMAIL_VERIFY_TOKEN_GENERATOR.check_token(user, token)
+        else:
+            result = EMAIL_VERIFY_TOKEN_GENERATOR.check_token(user, token)
     except ObjectDoesNotExist:
         result = False
     if result:

--- a/api/ellandi/verification.py
+++ b/api/ellandi/verification.py
@@ -106,10 +106,11 @@ def me_send_verification_email_view(request):
 def verification_view(request, user_id, token):
     try:
         user = models.User.objects.get(id=user_id)
+        if user.verified:
+            result = False
         result = EMAIL_VERIFY_TOKEN_GENERATOR.check_token(user, token)
     except ObjectDoesNotExist:
         result = False
-
     if result:
         user.verified = True
         user.save()
@@ -189,6 +190,8 @@ def check_token(request, user_id, token):
     token_generator = EMAIL_MAPPING[token_type]["token_generator"]
     try:
         user = models.User.objects.get(id=user_id)
+        if token_type == "email-verification" and user.verified:
+            return Response({"valid": False})
     except ObjectDoesNotExist:
         return Response({"valid": False})
     result = bool(token_generator.check_token(user, token))

--- a/api/tests/test_token_verification.py
+++ b/api/tests/test_token_verification.py
@@ -78,8 +78,7 @@ def test_resend_verify_email(client, user_id):
     assert user.verified
 
     response = client.get(url)
-    assert response.status_code == 400, response.status_code
-    #assert response.status_code == 400, "Token invalid once user is verified"
+    assert response.status_code == 400, "Token invalid once user is verified"
 
 
 @utils.with_client

--- a/api/tests/test_token_verification.py
+++ b/api/tests/test_token_verification.py
@@ -77,6 +77,10 @@ def test_resend_verify_email(client, user_id):
     user = User.objects.get(id=user_id)
     assert user.verified
 
+    response = client.get(url)
+    assert response.status_code == 400, response.status_code
+    #assert response.status_code == 400, "Token invalid once user is verified"
+
 
 @utils.with_client
 @override_settings(SEND_VERIFICATION_EMAIL=True)

--- a/web/context/UiContext.tsx
+++ b/web/context/UiContext.tsx
@@ -22,7 +22,7 @@ const ecodes = {
     </>
   ),
   3: 'You are no longer logged in. Sign in to continue using the platform',
-  4: "Your 'reset password' link expired after 24 hours or has already been used"
+  4: "Your link expired after 24 hours or has already been used"
 }
 
 const UIContext = createContext<Props>({} as Props)

--- a/web/context/UiContext.tsx
+++ b/web/context/UiContext.tsx
@@ -22,7 +22,7 @@ const ecodes = {
     </>
   ),
   3: 'You are no longer logged in. Sign in to continue using the platform',
-  4: "Your 'confirm your email address' link expired after 24 hours or has already been used"
+  4: "Your 'reset password' link expired after 24 hours or has already been used"
 }
 
 const UIContext = createContext<Props>({} as Props)


### PR DESCRIPTION
Email verification link is no longer valid once it has been clicked once (i.e. user has been verified).
- https://trello.com/c/3701nnB5/129-email-verification

"Fixes" password issue: https://trello.com/c/C6kVSuzT/316-bug-forgotten-password-reset-link-remains-valid
- No API changes required (just needed frontend changes to that token is checked when going to that page)
- Made a small change to error text so it's more accurate
- Password link is valid for 24 hours, invalidated after this time, or if a new link has been sent

To test locally: 
- Change `SEND_VERIFICATION_EMAIL` to `True`, and ensure outputs are going to console `EMAIL_BACKEND_TYPE` (I usually just change settings file, but you can prob set env vars).
- Find the link in the console outputs (you will have to change `localhost:3000` to `localhost`.

@rottitime - worth you eyeballing this too.