### PR TITLE
1021 stop cron job running against develop

### DIFF
--- a/.github/workflows/cf-cron.yml
+++ b/.github/workflows/cf-cron.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        environment: [prod, staging, develop]
+        environment: [prod, staging]
 
     env:
       CF_SPACE: ${{ matrix.environment }}

--- a/.github/workflows/cf-cron.yml
+++ b/.github/workflows/cf-cron.yml
@@ -1,8 +1,8 @@
 name: Run Recommender App
 
 on:
-  schedule:
-  - cron: '0 0 * * *'
+  # schedule:
+  # - cron: '0 0 * * *'
   workflow_dispatch:
     branches:
       - temp


### PR DESCRIPTION
ellandi services are not running in develop at the moment so this doesn't need to be running in develop either